### PR TITLE
로그인 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,6 @@ wldbszpflrxj">변지윤</a></td>
 - ### 계좌 목록
 - <video src='https://user-images.githubusercontent.com/72956443/192097614-09051b5d-1d1c-49c9-9e6f-0d955d167ae1.mp4' width=100% />
 
-> ## 테스트 계정
-
-- email: pre-onboarding-team2@wanted.com
-- password: qwer1234
-
 > ## 실행 방법
 
 ```sh
@@ -40,7 +35,15 @@ yarn workspace backend start
 
 # 새로운 터미널에서
 yarn workspace frontend dev
+
 ```
+
+#### 이후 브라우저에서 `http://localhost:5173/`로 접속하면 실행할 수 있습니다.
+
+> ## 테스트 계정
+
+- email: pre-onboarding-team2@wanted.com
+- password: qwer1234
 
 > ## 목차
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,7 +17,7 @@ const App = () => (
       <Route path={ROUTES.HOME} element={<Login />} />
       <Route path={ROUTES.LOGIN} element={<Login />} />
       <Route path={ROUTES.LOGOUT} element={<Logout />} />
-      <Route path={ROUTES.ACOOUNTS} element={<AccountList />} />
+      <Route path={ROUTES.ACCOUNTS} element={<AccountList />} />
       <Route path={`${ROUTES.ACCOUNT}/:accountId`} element={<Account />} />
       <Route path={`${ROUTES.USER}/:userId`} element={<User />} />
       <Route path={ROUTES.USERSLIST} element={<UsersList />} />

--- a/frontend/src/components/LoginForm/LoginForm.jsx
+++ b/frontend/src/components/LoginForm/LoginForm.jsx
@@ -42,7 +42,7 @@ const LoginForm = () => {
   };
 
   useEffect(() => {
-    if (isAuthenticated) navigate(ROUTES.HOME);
+    if (isAuthenticated) navigate(ROUTES.ACCOUNTS);
   }, [isAuthenticated, navigate]);
 
   return (

--- a/frontend/src/components/common/Layout/Sidebar/Sidebar.jsx
+++ b/frontend/src/components/common/Layout/Sidebar/Sidebar.jsx
@@ -7,7 +7,7 @@ import { ROUTES } from '@/constants/routes';
 
 const siders = [
   { id: 1, name: '대시보드', keyword: 'home', link: ROUTES.HOME, icon: <CalendarIcon /> },
-  { id: 2, name: '계좌 목록', keyword: 'account', link: ROUTES.ACOOUNTS, icon: <HamburgerIcon /> },
+  { id: 2, name: '계좌 목록', keyword: 'account', link: ROUTES.ACCOUNTS, icon: <HamburgerIcon /> },
   { id: 3, name: '사용자 목록', keyword: 'user', link: ROUTES.USERSLIST, icon: <StarIcon /> },
   { id: 9999, name: '로그아웃', keyword: 'logout', link: ROUTES.LOGOUT, icon: <UnlockIcon /> },
 ];

--- a/frontend/src/constants/routes.js
+++ b/frontend/src/constants/routes.js
@@ -1,7 +1,7 @@
 export const ROUTES = {
   HOME: '/',
   LOGIN: '/login',
-  ACOOUNTS: '/accounts',
+  ACCOUNTS: '/accounts',
   USER: '/user',
   ACCOUNT: '/account',
   USERSLIST: '/users',


### PR DESCRIPTION
## 변경사항

- 로그인 완료하면 계좌 목록 페이지로 이동할 수 있도록 navigate 라우트 변경
- 이미 로그인된 유저(토큰이 있는 유저)의 경우 계좌 목록 페이지로 이동하게끔 라우트 변경
- 라우트의 오탈자 변경 및 관련 코드 수정
- 실행방법 관련 README.md에 `http://localhost:5173/`로 접속해야 한다는 안내 추가
